### PR TITLE
Adding RenameLightOperation to change the name of a light

### DIFF
--- a/src/main/java/com/ss/editor/ui/control/model/node/light/LightTreeNode.java
+++ b/src/main/java/com/ss/editor/ui/control/model/node/light/LightTreeNode.java
@@ -3,9 +3,11 @@ package com.ss.editor.ui.control.model.node.light;
 import com.jme3.light.Light;
 import com.ss.editor.annotation.FXThread;
 import com.ss.editor.annotation.FromAnyThread;
+import com.ss.editor.model.undo.editor.ChangeConsumer;
 import com.ss.editor.ui.Icons;
 import com.ss.editor.ui.control.model.tree.action.RemoveLightAction;
 import com.ss.editor.ui.control.model.tree.action.RenameNodeAction;
+import com.ss.editor.ui.control.model.tree.action.operation.RenameLightOperation;
 import com.ss.editor.ui.control.tree.NodeTree;
 import com.ss.editor.ui.control.tree.node.TreeNode;
 import com.ss.rlib.util.StringUtils;
@@ -14,6 +16,8 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static com.ss.rlib.util.ObjectUtils.notNull;
 
 /**
  * The base implementation of {@link TreeNode} to present lights.
@@ -40,6 +44,9 @@ public class LightTreeNode<T extends Light> extends TreeNode<T> {
     public void changeName(@NotNull final NodeTree<?> nodeTree, @NotNull final String newName) {
         final T element = getElement();
         element.setName(newName);
+
+        final ChangeConsumer consumer = notNull(nodeTree.getChangeConsumer());
+        consumer.execute(new RenameLightOperation(element.getName(), newName, element));
     }
 
     @Override

--- a/src/main/java/com/ss/editor/ui/control/model/tree/action/operation/RenameLightOperation.java
+++ b/src/main/java/com/ss/editor/ui/control/model/tree/action/operation/RenameLightOperation.java
@@ -1,0 +1,61 @@
+package com.ss.editor.ui.control.model.tree.action.operation;
+
+
+import com.jme3.light.Light;
+import com.ss.editor.model.undo.editor.ModelChangeConsumer;
+import com.ss.editor.model.undo.impl.AbstractEditorOperation;
+import org.jetbrains.annotations.NotNull;
+
+public class RenameLightOperation extends AbstractEditorOperation<ModelChangeConsumer> {
+    /**
+     * The constant PROPERTY_NAME.
+     */
+    public static final String PROPERTY_NAME = "name";
+
+    /**
+     * The old name.
+     */
+    @NotNull
+    private final String oldName;
+
+    /**
+     * The new name.
+     */
+    @NotNull
+    private final String newName;
+
+    /**
+     * The node.
+     */
+    @NotNull
+    private final Light light;
+
+    /**
+     * Instantiates a new Rename node operation.
+     *
+     * @param oldName the old name
+     * @param newName the new name
+     * @param light the light
+     */
+    public RenameLightOperation(@NotNull final String oldName, @NotNull final String newName, @NotNull final Light light) {
+        this.oldName = oldName;
+        this.newName = newName;
+        this.light = light;
+    }
+
+    @Override
+    protected void redoImpl(@NotNull final ModelChangeConsumer editor) {
+        EXECUTOR_MANAGER.addJMETask(() -> {
+            light.setName(newName);
+            EXECUTOR_MANAGER.addFXTask(() -> editor.notifyFXChangeProperty(light, PROPERTY_NAME));
+        });
+    }
+
+    @Override
+    protected void undoImpl(@NotNull final ModelChangeConsumer editor) {
+        EXECUTOR_MANAGER.addJMETask(() -> {
+            light.setName(oldName);
+            EXECUTOR_MANAGER.addFXTask(() -> editor.notifyFXChangeProperty(light, PROPERTY_NAME));
+        });
+    }
+}


### PR DESCRIPTION
Hello, I noticed that when changing the name of a light, it does not register directly. I added the RenameLightOperation class that seemed to be missing