### PR TITLE
Adding copy and paste functions for the nodes in the scenegraph

### DIFF
--- a/src/main/java/com/ss/editor/Messages.java
+++ b/src/main/java/com/ss/editor/Messages.java
@@ -215,6 +215,8 @@ public class Messages {
 
     public static final String MODEL_NODE_TREE_ACTION_REMOVE;
     public static final String MODEL_NODE_TREE_ACTION_RENAME;
+    public static final String MODEL_NODE_TREE_ACTION_COPY;
+    public static final String MODEL_NODE_TREE_ACTION_PASTE;
     public static final String MODEL_NODE_TREE_ACTION_OPTIMIZE_GEOMETRY;
     public static final String MODEL_NODE_TREE_ACTION_TOOLS;
     public static final String MODEL_NODE_TREE_ACTION_CREATE;
@@ -893,6 +895,8 @@ public class Messages {
 
         MODEL_NODE_TREE_ACTION_REMOVE = bundle.getString("ModelNodeTreeActionRemove");
         MODEL_NODE_TREE_ACTION_RENAME = bundle.getString("ModelNodeTreeActionRename");
+        MODEL_NODE_TREE_ACTION_COPY = bundle.getString("ModelNodeTreeActionCopy");
+        MODEL_NODE_TREE_ACTION_PASTE = bundle.getString("ModelNodeTreeActionPaste");
         MODEL_NODE_TREE_ACTION_OPTIMIZE_GEOMETRY = bundle.getString("ModelNodeTreeActionOptimizeGeometry");
         MODEL_NODE_TREE_ACTION_TOOLS = bundle.getString("ModelNodeTreeActionTools");
         MODEL_NODE_TREE_ACTION_CREATE = bundle.getString("ModelNodeTreeActionCreate");

--- a/src/main/java/com/ss/editor/ui/control/model/node/spatial/SpatialTreeNode.java
+++ b/src/main/java/com/ss/editor/ui/control/model/node/spatial/SpatialTreeNode.java
@@ -24,8 +24,7 @@ import com.ss.editor.ui.Icons;
 import com.ss.editor.ui.control.model.node.control.ControlTreeNode;
 import com.ss.editor.ui.control.model.node.light.LightTreeNode;
 import com.ss.editor.ui.control.model.tree.ModelNodeTree;
-import com.ss.editor.ui.control.model.tree.action.AddUserDataAction;
-import com.ss.editor.ui.control.model.tree.action.RemoveNodeAction;
+import com.ss.editor.ui.control.model.tree.action.*;
 import com.ss.editor.ui.control.model.tree.action.control.CreateCustomControlAction;
 import com.ss.editor.ui.control.model.tree.action.control.CreateLightControlAction;
 import com.ss.editor.ui.control.model.tree.action.control.CreateMotionControlAction;
@@ -83,6 +82,15 @@ public class SpatialTreeNode<T extends Spatial> extends TreeNode<T> {
         if (canRemove()) {
             items.add(new RemoveNodeAction(nodeTree, this));
         }
+
+        if(canCopy()){
+            items.add(new CopyNodeAction(nodeTree,this));
+        }
+
+        if(DataCopy.copySpatial != null){
+            items.add(new PasteNodeAction(nodeTree,this));
+        }
+
 
         super.fillContextMenu(nodeTree, items);
     }
@@ -182,6 +190,7 @@ public class SpatialTreeNode<T extends Spatial> extends TreeNode<T> {
 
         return menu;
     }
+
 
     /**
      * Create tool menu menu.

--- a/src/main/java/com/ss/editor/ui/control/model/tree/action/CopyNodeAction.java
+++ b/src/main/java/com/ss/editor/ui/control/model/tree/action/CopyNodeAction.java
@@ -1,0 +1,29 @@
+package com.ss.editor.ui.control.model.tree.action;
+
+import com.jme3.scene.Spatial;
+import com.ss.editor.Messages;
+import com.ss.editor.model.undo.editor.ModelChangeConsumer;
+import com.ss.editor.ui.control.model.node.spatial.NodeTreeNode;
+import com.ss.editor.ui.control.tree.NodeTree;
+import com.ss.editor.ui.control.tree.action.AbstractNodeAction;
+import com.ss.editor.ui.control.tree.node.TreeNode;
+import org.jetbrains.annotations.NotNull;
+
+public class CopyNodeAction extends AbstractNodeAction<ModelChangeConsumer> {
+
+    public CopyNodeAction(@NotNull NodeTree<?> nodeTree, @NotNull TreeNode<?> node) {
+        super(nodeTree, node);
+    }
+
+    @NotNull
+    @Override
+    protected String getName() {
+        return Messages.MODEL_NODE_TREE_ACTION_COPY;
+    }
+
+    @Override
+    protected void process() {
+        super.process();
+        DataCopy.copySpatial = (NodeTreeNode) this.getNode();
+    }
+}

--- a/src/main/java/com/ss/editor/ui/control/model/tree/action/DataCopy.java
+++ b/src/main/java/com/ss/editor/ui/control/model/tree/action/DataCopy.java
@@ -1,0 +1,9 @@
+package com.ss.editor.ui.control.model.tree.action;
+
+import com.jme3.scene.Spatial;
+import com.ss.editor.ui.control.model.node.spatial.NodeTreeNode;
+
+public class DataCopy
+{
+    public static NodeTreeNode copySpatial = null;
+}

--- a/src/main/java/com/ss/editor/ui/control/model/tree/action/PasteNodeAction.java
+++ b/src/main/java/com/ss/editor/ui/control/model/tree/action/PasteNodeAction.java
@@ -1,0 +1,42 @@
+package com.ss.editor.ui.control.model.tree.action;
+
+import com.jme3.scene.Node;
+import com.jme3.scene.Spatial;
+import com.ss.editor.Messages;
+import com.ss.editor.extension.scene.SceneLayer;
+import com.ss.editor.model.undo.editor.ChangeConsumer;
+import com.ss.editor.model.undo.editor.ModelChangeConsumer;
+import com.ss.editor.ui.control.model.node.spatial.NodeTreeNode;
+import com.ss.editor.ui.control.model.node.spatial.SpatialTreeNode;
+import com.ss.editor.ui.control.model.tree.action.operation.AddChildOperation;
+import com.ss.editor.ui.control.tree.NodeTree;
+import com.ss.editor.ui.control.tree.action.AbstractNodeAction;
+import com.ss.editor.ui.control.tree.node.TreeNode;
+import org.jetbrains.annotations.NotNull;
+
+import static com.ss.editor.util.EditorUtil.getDefaultLayer;
+import static com.ss.rlib.util.ObjectUtils.notNull;
+
+public class PasteNodeAction extends AbstractNodeAction<ModelChangeConsumer> {
+
+    public PasteNodeAction(@NotNull NodeTree<?> nodeTree, @NotNull TreeNode<?> node) {
+        super(nodeTree, node);
+    }
+
+    @NotNull
+    @Override
+    protected String getName() {
+        return Messages.MODEL_NODE_TREE_ACTION_PASTE;
+    }
+
+    @Override
+    protected void process() {
+        super.process();
+
+        if(DataCopy.copySpatial != null){
+            final ChangeConsumer consumer = notNull(this.getNodeTree().getChangeConsumer());
+            consumer.execute(new AddChildOperation(((Spatial)DataCopy.copySpatial.getElement()).clone(),(Node)this.getNode().getElement()));
+        }
+
+    }
+}

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -193,6 +193,8 @@ SceneFileEditorToolLayers=Layers
 
 ModelNodeTreeActionRemove=Remove
 ModelNodeTreeActionRename=Rename
+ModelNodeTreeActionCopy=Copy Node
+ModelNodeTreeActionPaste=Paste Node
 ModelNodeTreeActionOptimizeGeometry=Optimize geometry
 ModelNodeTreeActionTools=Tools
 ModelNodeTreeActionCreate=Create

--- a/src/test/java/com/ss/editor/ui/control/model/tree/action/DataCopyTest.groovy
+++ b/src/test/java/com/ss/editor/ui/control/model/tree/action/DataCopyTest.groovy
@@ -1,0 +1,4 @@
+package com.ss.editor.ui.control.model.tree.action
+
+class DataCopyTest extends GroovyTestCase {
+}


### PR DESCRIPTION
Hello,
These are options for copying and pasting a node from the scenegraph.

Icons are not created yet

![copypaste](https://user-images.githubusercontent.com/10273261/34469949-28a6c4ac-ef28-11e7-8625-2d22025c9f15.jpg)

